### PR TITLE
Builds sprite.svg at start of dev and on build

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 *.snap
+*.md

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { readFileSync, writeFileSync } from 'fs'
-import { type PluginOption, type ViteDevServer, normalizePath, ResolvedConfig } from 'vite'
+import { type PluginOption, type ResolvedConfig, type ViteDevServer, normalizePath } from 'vite'
 import picomatch from 'picomatch'
 import colors from 'picocolors'
 import SVGSpriter from 'svg-sprite'

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,27 @@ function ViteSvgSpriteWrapper(options: Options = {}): PluginOption {
     {
       name: 'vite-plugin-svg-sprite:serve',
       apply: 'serve',
+      configResolved(_config) {
+        config = _config
+      },
+      async buildStart() {
+        generateSvgSprite(icons, outputDir, options)
+          .then((res) => {
+            config.logger.info(
+              `${colors.green('sprite generated')} ${colors.dim(res)}`,
+              {
+                clear: true,
+                timestamp: true,
+              },
+            )
+          })
+          .catch((err) => {
+            config.logger.info(
+              `${colors.red('sprite error')} ${colors.dim(err)}`,
+              { clear: true, timestamp: true },
+            )
+          })
+      },
       config: () => ({ server: { watch: { disableGlobbing: false } } }),
       configureServer({ watcher, ws, config: { logger } }: ViteDevServer) {
         const iconsPath = normalizePaths(root, icons)


### PR DESCRIPTION
Fixes https://github.com/vshepel/vite-svg-sprite-wrapper/issues/1

Will generate the spite.svg on builds as well as for dev.

Something I couldn't figure out was how to add the generated sprite to the manifest.json - which I think would be a nice to have.