### PR TITLE
feature: add option to disable fill-currentColor, and enable stroke-currentColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ export default defineConfig({
        */
       sprite?: SVGSpriter.Config
       /**
+       * Defines if the svg's fill should be normalized to currentColor
+       *
+       * @default true
+       */
+      spriteNormalizeFill?: boolean
+      /**
+       * Defines if the svg's stroke should be normalized to currentColor
+       *
+       * @default false
+       */
+      spriteNormalizeStroke?: boolean
+      /**
        * Defines if a type should be generated
        * @default false
        */

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,18 @@ export interface Options {
    */
   sprite?: SVGSpriter.Config
   /**
+   * Defines if the svg's fill should be normalized to currentColor
+   *
+   * @default true
+   */
+  spriteNormalizeFill?: boolean
+  /**
+   * Defines if the svg's stroke should be normalized to currentColor
+   *
+   * @default false
+   */
+  spriteNormalizeStroke?: boolean
+  /**
    * Defines if a type should be generated
    * @default false
    */
@@ -51,6 +63,8 @@ export const defaultOptions: Required<Options> = {
   icons: 'src/assets/images/svg/*.svg',
   outputDir: 'src/public/images',
   sprite: {},
+  spriteNormalizeFill: true,
+  spriteNormalizeStroke: false,
   generateType: false,
   typeName: 'SvgIcons',
   typeFileName: 'svg-icons',
@@ -71,6 +85,40 @@ function normalizePaths(root: string, path: string | undefined): string[] {
 }
 
 function generateConfig(outputDir: string, options: Options): SVGSpriter.Config {
+  const svgoPlugins = [
+    { name: 'preset-default' },
+    {
+      name: 'removeAttrs',
+      params: {
+        attrs: [`*:(data-*|style${options.spriteNormalizeFill ? '|fill' : ''}${options.spriteNormalizeStroke ? '|stroke' : ''}):*`],
+      },
+    },
+    'removeXMLNS',
+  ]
+
+  if (options.spriteNormalizeFill) {
+    svgoPlugins.push({
+      name: 'addAttributesToSVGElement',
+      params: {
+        // @ts-expect-error [need to fix type for plugins property]
+        attributes: [
+          { fill: 'currentColor' },
+        ],
+      },
+    })
+  }
+  if (options.spriteNormalizeStroke) {
+    svgoPlugins.push({
+      name: 'addAttributesToSVGElement',
+      params: {
+        // @ts-expect-error [need to fix type for plugins property]
+        attributes: [
+          { stroke: 'currentColor' },
+        ],
+      },
+    })
+  }
+
   return {
     dest: normalizePath(resolve(root, outputDir)),
     mode: {
@@ -86,24 +134,7 @@ function generateConfig(outputDir: string, options: Options): SVGSpriter.Config 
         {
           svgo: {
             // @ts-expect-error [need to fix type for plugins property]
-            plugins: [
-              { name: 'preset-default' },
-              {
-                name: 'removeAttrs',
-                params: {
-                  attrs: ['*:(data-*|style|fill):*'],
-                },
-              },
-              {
-                name: 'addAttributesToSVGElement',
-                params: {
-                  attributes: [
-                    { fill: 'currentColor' },
-                  ],
-                },
-              },
-              'removeXMLNS',
-            ],
+            plugins: svgoPlugins,
           },
         },
       ],


### PR DESCRIPTION
By default this plugin always removes the existing 'fill' value in icons, and replaces it with 'fill="currentColor"'.

This does not work with outline icons, since they have a stroke instead of a fill. In the sprite; they get both, which makes them fully colored instead of outlined.  

This can be overridden by copying the default value for the 'sprite'-parameter, and removing the fill-related pieces. This PR adds two options, `spriteNormalizeFill`, which defaults to `true` and `spriteNormalizeStroke` which defaults to `false`. This makes sure that the default behaviour of the plugin is not changed.